### PR TITLE
postfixを追加

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -13,13 +13,13 @@ var listCmd = &cobra.Command{
 	Short: "辞書から英語と日本語訳のリストを出力する",
 	Long:  `抽出した辞書の英語と日本語訳のリストを出力する`,
 	Run: func(cmd *cobra.Command, args []string) {
-		var filename, pre, enOnly, jaOnly, tsv bool
+		var filename, affix, enOnly, jaOnly, tsv bool
 		var err error
 		if filename, err = cmd.PersistentFlags().GetBool("filename"); err != nil {
 			log.Println(err)
 			return
 		}
-		if pre, err = cmd.PersistentFlags().GetBool("pre"); err != nil {
+		if affix, err = cmd.PersistentFlags().GetBool("pre"); err != nil {
 			log.Println(err)
 			return
 		}
@@ -41,15 +41,15 @@ var listCmd = &cobra.Command{
 			jpugdoc.TSVList(fileNames)
 			return
 		}
-		jpugdoc.List(filename, pre, enOnly, jaOnly, fileNames)
+		jpugdoc.List(filename, affix, enOnly, jaOnly, fileNames)
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(listCmd)
 	listCmd.PersistentFlags().BoolP("filename", "f", false, "filename")
-	listCmd.PersistentFlags().BoolP("pre", "p", false, "prefix")
-	listCmd.PersistentFlags().BoolP("en", "e", false, "English")
-	listCmd.PersistentFlags().BoolP("ja", "j", false, "Japanese")
-	listCmd.PersistentFlags().BoolP("tsv", "t", false, "tsv")
+	listCmd.PersistentFlags().BoolP("pre", "p", false, "prefix/postfixも出力する")
+	listCmd.PersistentFlags().BoolP("en", "e", false, "Englishのみ出力する")
+	listCmd.PersistentFlags().BoolP("ja", "j", false, "Japaneseのみ出力する")
+	listCmd.PersistentFlags().BoolP("tsv", "t", false, "tsv形式で出力する")
 }

--- a/cmd/mt.go
+++ b/cmd/mt.go
@@ -19,7 +19,7 @@ var mtCmd = &cobra.Command{
 		en = strings.ReplaceAll(en, "\n", " ")
 		w := os.Stdout
 		if err := jpugdoc.MT(w, en); err != nil {
-			log.Fatal(err)
+			log.Fatalf("Failed to translate string: %v", err)
 		}
 	},
 }

--- a/jpugdoc/extract.go
+++ b/jpugdoc/extract.go
@@ -12,6 +12,7 @@ type Catalog struct {
 	en       string
 	ja       string
 	preCDATA string
+	post     string
 }
 
 func (c Catalog) String() string {

--- a/jpugdoc/ignore.go
+++ b/jpugdoc/ignore.go
@@ -26,7 +26,7 @@ func writeIgnore(f io.Writer, ignores []string) error {
 	for _, ig := range ignores {
 		_, err := fmt.Fprintf(f, "%s\n", ig)
 		if err != nil {
-			log.Fatal(err)
+			return fmt.Errorf("failed to write ignore: %w", err)
 		}
 	}
 	return nil

--- a/jpugdoc/jpugdoc.go
+++ b/jpugdoc/jpugdoc.go
@@ -111,7 +111,8 @@ func saveCatalog(fileName string, catalogs []Catalog) {
 		fmt.Fprintf(f, "␝%s␟", catalog.pre)
 		fmt.Fprintf(f, "%s␟", catalog.en)
 		fmt.Fprintf(f, "%s␞", catalog.ja)
-		fmt.Fprintf(f, "%s␞\n", catalog.preCDATA)
+		fmt.Fprintf(f, "%s␞", catalog.preCDATA)
+		fmt.Fprintf(f, "%s␞\n", catalog.post)
 	}
 }
 
@@ -137,6 +138,7 @@ func getCatalogs(src []byte) []Catalog {
 			en:       string(re[2]),
 			ja:       string(re[3]),
 			preCDATA: string(re[4]),
+			post:     string(re[5]),
 		}
 		catalogs = append(catalogs, c)
 	}

--- a/jpugdoc/list.go
+++ b/jpugdoc/list.go
@@ -11,28 +11,27 @@ import (
 
 // 英日辞書の内容を表示する
 // wf: ファイル名を表示する
-// pre: preタグを表示する
+// affix: pre/postを表示する
 // enOnly: 英文のみ表示する
 // jaOnly: 日本語のみ表示する
 // fileNames: ファイル名のリスト
-func List(wf bool, pre bool, enOnly bool, jaOnly bool, fileNames []string) {
-	w := io.Writer(os.Stdout)
-	list(w, wf, pre, enOnly, jaOnly, fileNames)
+func List(wf bool, affix bool, enOnly bool, jaOnly bool, fileNames []string) {
+	list(os.Stdout, wf, affix, enOnly, jaOnly, fileNames)
 }
 
-func list(w io.Writer, wf bool, pre bool, enOnly bool, jaOnly bool, fileNames []string) {
+func list(w io.Writer, wf bool, affix bool, enOnly bool, jaOnly bool, fileNames []string) {
 	for _, fileName := range fileNames {
 		if wf {
 			fmt.Fprintln(w, gchalk.Red(fileName))
 		}
 		catalogs := loadCatalog(fileName)
-		writeCatalog(w, catalogs, pre, enOnly, jaOnly)
+		writeCatalog(w, catalogs, affix, enOnly, jaOnly)
 	}
 }
 
-func writeCatalog(w io.Writer, catalogs []Catalog, pre bool, enOnly bool, jaOnly bool) {
+func writeCatalog(w io.Writer, catalogs []Catalog, affix bool, enOnly bool, jaOnly bool) {
 	for _, catalog := range catalogs {
-		if pre {
+		if affix {
 			fmt.Fprintln(w, gchalk.Blue(catalog.pre))
 		} else {
 			if catalog.en == "" {
@@ -45,14 +44,16 @@ func writeCatalog(w io.Writer, catalogs []Catalog, pre bool, enOnly bool, jaOnly
 		if !enOnly {
 			fmt.Fprintln(w, catalog.ja)
 		}
+		if affix {
+			fmt.Fprintln(w, gchalk.Blue(catalog.post))
+		}
 		fmt.Fprintln(w)
 	}
 }
 
 // 英日辞書の内容をTSV形式で表示する
 func TSVList(fileNames []string) {
-	w := io.Writer(os.Stdout)
-	tsvList(w, fileNames)
+	tsvList(os.Stdout, fileNames)
 }
 
 func tsvList(w io.Writer, fileNames []string) {

--- a/jpugdoc/mt.go
+++ b/jpugdoc/mt.go
@@ -27,9 +27,7 @@ func MT(w io.Writer, origin string) error {
 			return fmt.Errorf("textra: %s", err)
 		}
 		if _, err := fmt.Fprintf(w, "%s: %s\n", gchalk.Green(apiType), ja); err != nil {
-			if err != nil {
-				return err
-			}
+			return err
 		}
 	}
 	return nil

--- a/jpugdoc/regexp.go
+++ b/jpugdoc/regexp.go
@@ -81,10 +81,10 @@ func endComment(src []byte) bool {
 	return ENDCOMMENT.Match(src)
 }
 
-// コメント始まりの追加に一致
+// <!-- コメント始まりの追加に一致
 var STARTADDCOMMENT = regexp.MustCompile(`\+<!--$`)
 
-// コメント終わりの追加に一致
+// --> コメント終わりの追加に一致
 var ENDADDCOMMENT = regexp.MustCompile(`\+-->$`)
 
 // CDATAが終わりコメントの始まりに一致
@@ -116,7 +116,7 @@ var MultiSpace = regexp.MustCompile(`\s+`)
 var MultiNL = regexp.MustCompile(`\n+`)
 
 // カタログから英語と日本語を取得
-var SPLITCATALOG = regexp.MustCompile(`(?s)␝(.*?)␟(.*?)␟(.*?)␞(.*?)␞`)
+var SPLITCATALOG = regexp.MustCompile(`(?s)␝(.*?)␟(.*?)␟(.*?)␞(.*?)␞(.*?)␞`)
 
 // 英単語 + /
 var ENWORD = regexp.MustCompile(`[/a-zA-Z_]+`)


### PR DESCRIPTION
extractで抽出したデータに対して、postfixを追加

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `affix` flag in CLI commands for enhanced pre/post display control.
	- Added support for a `post` field in the catalog data structure to accommodate additional information.
- **Improvements**
	- Improved error messages across various functions for better clarity and troubleshooting.
	- Updated regular expressions with HTML comment markers for more precise content matching.
- **Bug Fixes**
	- Refined error handling logic in multiple files to ensure more robust and informative responses to failures.
- **Refactor**
	- Simplified error handling in writing operations to enhance code maintainability.
	- Adjusted catalog saving and retrieval logic to incorporate new `post` field handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->