### PR TITLE
Add postfix

### DIFF
--- a/jpugdoc/extract.go
+++ b/jpugdoc/extract.go
@@ -12,6 +12,7 @@ type Catalog struct {
 	en       string
 	ja       string
 	preCDATA string
+	post     string
 }
 
 func (c Catalog) String() string {

--- a/jpugdoc/jpugdoc.go
+++ b/jpugdoc/jpugdoc.go
@@ -111,7 +111,8 @@ func saveCatalog(fileName string, catalogs []Catalog) {
 		fmt.Fprintf(f, "␝%s␟", catalog.pre)
 		fmt.Fprintf(f, "%s␟", catalog.en)
 		fmt.Fprintf(f, "%s␞", catalog.ja)
-		fmt.Fprintf(f, "%s␞\n", catalog.preCDATA)
+		fmt.Fprintf(f, "%s␞", catalog.preCDATA)
+		fmt.Fprintf(f, "%s␞\n", catalog.post)
 	}
 }
 
@@ -137,6 +138,7 @@ func getCatalogs(src []byte) []Catalog {
 			en:       string(re[2]),
 			ja:       string(re[3]),
 			preCDATA: string(re[4]),
+			post:     string(re[5]),
 		}
 		catalogs = append(catalogs, c)
 	}

--- a/jpugdoc/jpugdoc_test.go
+++ b/jpugdoc/jpugdoc_test.go
@@ -58,7 +58,7 @@ func Test_getCatalogs(t *testing.T) {
 		{
 			name: "testTitle",
 			args: args{
-				src: []byte(`␝␟ <title>Acronyms</title>␟ <title>頭字語</title>␞␞`),
+				src: []byte(`␝␟ <title>Acronyms</title>␟ <title>頭字語</title>␞␞␞`),
 			},
 			want: []Catalog{
 				{
@@ -66,6 +66,7 @@ func Test_getCatalogs(t *testing.T) {
 					en:       " <title>Acronyms</title>",
 					ja:       " <title>頭字語</title>",
 					preCDATA: "",
+					post:     "",
 				},
 			},
 		},

--- a/jpugdoc/list.go
+++ b/jpugdoc/list.go
@@ -30,20 +30,24 @@ func list(w io.Writer, wf bool, pre bool, enOnly bool, jaOnly bool, fileNames []
 	}
 }
 
-func writeCatalog(w io.Writer, catalogs []Catalog, pre bool, enOnly bool, jaOnly bool) {
+func writeCatalog(w io.Writer, catalogs []Catalog, suffix bool, enOnly bool, jaOnly bool) {
 	for _, catalog := range catalogs {
-		if pre {
-			fmt.Fprintln(w, gchalk.Blue(catalog.pre))
+		en := strings.Trim(catalog.en, "\n")
+		if !suffix && en == "" {
+			continue
+		}
+
+		if suffix {
+			fmt.Fprintln(w, gchalk.Blue(strings.Trim(catalog.pre, "\n")))
 		}
 		if !jaOnly {
-			if pre || catalog.en != "" {
-				fmt.Fprintln(w, gchalk.Green(catalog.en))
-			} else {
-				fmt.Fprintln(w, gchalk.Green(catalog.pre))
-			}
+			fmt.Fprintln(w, gchalk.Green(en))
 		}
 		if !enOnly {
-			fmt.Fprintln(w, catalog.ja)
+			fmt.Fprintln(w, strings.Trim(catalog.ja, "\n"))
+		}
+		if suffix {
+			fmt.Fprintln(w, gchalk.Blue(strings.Trim(catalog.post, "\n")))
 		}
 		fmt.Fprintln(w)
 	}

--- a/jpugdoc/regexp.go
+++ b/jpugdoc/regexp.go
@@ -116,7 +116,7 @@ var MultiSpace = regexp.MustCompile(`\s+`)
 var MultiNL = regexp.MustCompile(`\n+`)
 
 // カタログから英語と日本語を取得
-var SPLITCATALOG = regexp.MustCompile(`(?s)␝(.*?)␟(.*?)␟(.*?)␞(.*?)␞`)
+var SPLITCATALOG = regexp.MustCompile(`(?s)␝(.*?)␟(.*?)␟(.*?)␞(.*?)␞(.*?)␞`)
 
 // 英単語 + /
 var ENWORD = regexp.MustCompile(`[/a-zA-Z_]+`)

--- a/jpugdoc/replace.go
+++ b/jpugdoc/replace.go
@@ -135,6 +135,19 @@ func (rep Rep) replaceCatalog(src []byte, catalog Catalog) []byte {
 			break
 		}
 
+		if catalog.post != "" {
+			start := p + pp + len(cen)
+			if start > len(src) {
+				ret = append(ret, src[p:]...)
+				break
+			}
+			if !bytes.HasPrefix(src[start:], []byte(catalog.post)) {
+				ret = append(ret, src[p:p+pp+len(catalog.en)]...)
+				p = p + pp + len(catalog.en)
+				continue
+			}
+		}
+
 		if !inComment(src[:p+pp]) {
 			ret = append(ret, src[p:p+pp]...)
 			if inCDATA(src[:p+pp]) {


### PR DESCRIPTION
Save the line after the original text as postfix
and use it for checking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced the ability to utilize a postfix in catalog entries, enhancing customization and formatting options.
- **Improvements**
	- Enhanced the catalog saving and retrieval process with formatting adjustments and new data handling.
- **Refactor**
	- Updated various parts of the code to support and efficiently utilize the new `post` field in the `Catalog` struct.
- **Tests**
	- Renamed and updated test cases to align with the new functionality and structure changes.
- **Bug Fixes**
	- Fixed output formatting issues by adjusting newline character placement and trimming logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->