### PR TITLE
Added limit option

### DIFF
--- a/cmd/mtreplace.go
+++ b/cmd/mtreplace.go
@@ -10,6 +10,12 @@ var mtreplaceCmd = &cobra.Command{
 	Use:   "mtreplace",
 	Short: "機械翻訳のマークを実際に置き換える",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		var limit int
+		var err error
+		if limit, err = cmd.PersistentFlags().GetInt("limit"); err != nil {
+			return err
+		}
+		jpugdoc.MaxTranslate = limit
 		fileNames := expandFileNames(args)
 		return jpugdoc.MTReplace(fileNames, false)
 	},
@@ -17,4 +23,5 @@ var mtreplaceCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(mtreplaceCmd)
+	mtreplaceCmd.PersistentFlags().IntP("limit", "l", 100, "Limit for API queries")
 }

--- a/jpugdoc/mtreplace.go
+++ b/jpugdoc/mtreplace.go
@@ -16,7 +16,7 @@ type MTType struct {
 
 var MTMARKREG = regexp.MustCompile(`«(.*?)»`)
 
-var MaxTranslate = 1
+var MaxTranslate = 100
 
 func MTReplace(fileNames []string, prompt bool) error {
 	cli, err := newTextra(Config)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new command-line flag `limit` allowing users to set the maximum number of API queries, providing better control over the translation process.
- **Refactor**
	- Updated the maximum translation limit from 1 to 100, enhancing the translation capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->