### PR TITLE
Changed to not replace wip

### DIFF
--- a/cmd/replace.go
+++ b/cmd/replace.go
@@ -18,6 +18,7 @@ var replaceCmd = &cobra.Command{
 		var similar int
 		var mts int
 		var prompt bool
+		var wip bool
 		var err error
 		if similar, err = cmd.PersistentFlags().GetInt("similar"); err != nil {
 			return err
@@ -40,9 +41,12 @@ var replaceCmd = &cobra.Command{
 		if prompt, err = cmd.PersistentFlags().GetBool("prompt"); err != nil {
 			return err
 		}
+		if wip, err = cmd.PersistentFlags().GetBool("wip"); err != nil {
+			return err
+		}
 
 		fileNames := expandFileNames(args)
-		return jpugdoc.Replace(fileNames, vtag, update, similar, mts, prompt)
+		return jpugdoc.Replace(fileNames, vtag, update, similar, mts, wip, prompt)
 	},
 }
 
@@ -53,5 +57,6 @@ func init() {
 	replaceCmd.PersistentFlags().StringP("vtag", "v", "", "original version tag")
 	replaceCmd.PersistentFlags().BoolP("mt", "", false, "Mark with machine translation")
 	replaceCmd.PersistentFlags().IntP("mts", "", 0, "Use machine translation with similarity %")
+	replaceCmd.PersistentFlags().BoolP("wip", "a", false, "Update even while work is in progress")
 	replaceCmd.PersistentFlags().BoolP("prompt", "i", false, "Prompt before each replacement")
 }

--- a/jpugdoc/extract.go
+++ b/jpugdoc/extract.go
@@ -79,12 +79,20 @@ func PARAExtraction(src []byte) []Catalog {
 	return pairs
 }
 
-// コメント（英語原文）と続く文書（日本語翻訳）のペア、残り文字列、エラーを返す
-// <!--
-// english
-// -->
-// japanese
-// の形式に一致しない場合はエラーを返す
+/*
+	コメント（英語原文）と続く文書（日本語翻訳）のペア、残り文字列、エラーを返す
+
+```xml
+
+	<!--
+	  english
+	-->
+	japanese
+
+```
+
+	の形式に一致しない場合はエラーを返す
+*/
 func newCatalog(para []byte) (Catalog, []byte, error) {
 	re := EXCOMMENT.FindSubmatch(para)
 	if len(re) < 3 {


### PR DESCRIPTION
Changed to require option to replace wip.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a "Work in Progress" (WIP) mode to enhance command functionality, allowing users to mark operations as preliminary.
	- Enhanced document translation capabilities to support mixed-language comments with new XML-like tagging, improving bilingual document handling.
- **Refactor**
	- Updated translation replacement logic to accommodate the WIP flag, ensuring more flexible processing.
	- Refined document extraction and replacement processes for better accuracy and efficiency in handling English and Japanese text pairs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->