### PR TITLE
There was a shortage of regular expressions

### DIFF
--- a/jpugdoc/regexp.go
+++ b/jpugdoc/regexp.go
@@ -201,7 +201,7 @@ func authorMatch(src []byte) []byte {
 	return []byte(ret[len(ret)-1])
 }
 
-var TITLE = regexp.MustCompile(`(?U)( *<title>[a-zA-Z0-9 \.\-]+</title>)\n([^\-])`)
+var TITLE = regexp.MustCompile(`(?U)( *<title>[a-zA-Z0-9 \.\-:]+</title>)\n([^\-])`)
 
 func titleMatch(src []byte) []byte {
 	ret := TITLE.FindSubmatch(src)

--- a/jpugdoc/regexp_test.go
+++ b/jpugdoc/regexp_test.go
@@ -424,13 +424,24 @@ func Test_titleMatch(t *testing.T) {
   <para>
  `),
 			},
-			want: []byte(` <title>Release 16.1</title`),
+			want: []byte(`  <title>Release 16.1</title>`),
+		},
+		{
+			name: "test5",
+			args: args{
+				src: []byte(` <formalpara>
+ <title>Release date:</title>
+ <para>2024-02-08</para>
+ </formalpara>
+`),
+			},
+			want: []byte(` <title>Release date:</title>`),
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := titleMatch(tt.args.src); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("titleMatch() = [%v], want [%v]", string(got), string(tt.want))
+				t.Errorf("titleMatch() = [%v]\n, want [%v]", string(got), string(tt.want))
 			}
 		})
 	}

--- a/jpugdoc/replace.go
+++ b/jpugdoc/replace.go
@@ -157,13 +157,11 @@ func (rep *Rep) replaceTitle(src []byte) []byte {
 		if strings.Contains(ent, "Release ") {
 			v := RELEASENUM.Find(en)
 			nja = "<title>リリース" + string(v) + "</title>"
-			log.Println(string(en))
 		}
 
 		if strings.Contains(ent, "Migration to Version") {
 			v := RELEASENUM.Find(en)
 			nja = "<title>バージョン" + string(v) + "への移行</title>"
-			log.Println(string(en))
 		}
 
 		if j, ok := rep.titles[ent]; ok {


### PR DESCRIPTION
There was something missing
in the regular expression for title.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved title recognition in documents by allowing colons in the title tag.
- **Chores**
	- Removed unnecessary logging related to title replacements in documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->