### PR TITLE
Improved idempotency of additional line

### DIFF
--- a/jpugdoc/common.go
+++ b/jpugdoc/common.go
@@ -55,6 +55,7 @@ var titleData = `
 <title>Transforms</title>,<title>変換</title>
 <title>Trigger Functions</title>,<title>トリガ関数</title>
 <title>Usage</title>,<title>使用方法</title>
+<title>Release Notes</title>,<title>リリースノート</title>
 <title>Release date:</title>,<title>リリース日:</title>
 <title>Changes</title>,<title>変更点</title>
 <title>Server</title>,<title>サーバ</title>
@@ -78,6 +79,9 @@ func titleMap() map[string]string {
 	lines := strings.Split(titleData, "\n")
 	m := make(map[string]string)
 	for _, line := range lines {
+		if line == "" {
+			continue
+		}
 		parts := strings.Split(line, ",")
 		if len(parts) != 2 {
 			log.Printf("Unexpected format in titleData: %s", line)

--- a/jpugdoc/diffextract.go
+++ b/jpugdoc/diffextract.go
@@ -179,7 +179,7 @@ func Extraction(diffSrc []byte) []Catalog {
 					indexj.WriteString("\n")
 					indexF = false
 					if index.Len() > 0 {
-						catalogs = addJaCatalogs(catalogs, index.String(), indexj)
+						catalogs = addJaCatalogs(catalogs, index.String(), indexj, postfix)
 					}
 					index.Reset()
 					indexj.Reset()
@@ -189,7 +189,7 @@ func Extraction(diffSrc []byte) []Catalog {
 				indexj.WriteString("\n")
 				indexF = false
 				if index.Len() > 0 {
-					catalogs = addJaCatalogs(catalogs, index.String(), indexj)
+					catalogs = addJaCatalogs(catalogs, index.String(), indexj, postfix)
 				}
 				index.Reset()
 				indexj.Reset()
@@ -221,13 +221,13 @@ func Extraction(diffSrc []byte) []Catalog {
 			}
 		}
 		if !addExtraF && addja.Len() != 0 {
-			catalogs = addJaCatalogs(catalogs, addPre, addja)
+			catalogs = addJaCatalogs(catalogs, addPre, addja, line)
 			addja.Reset()
 		}
 	}
 	// last
 	catalogs = addCatalogs(catalogs, prefix, en, ja, preCDATA, postfix)
-	catalogs = addJaCatalogs(catalogs, addPre, addja)
+	catalogs = addJaCatalogs(catalogs, addPre, addja, "")
 	return catalogs
 }
 
@@ -305,14 +305,14 @@ func addCatalogs(catalogs []Catalog, pre string, en strings.Builder, ja strings.
 	return catalogs
 }
 
-func addJaCatalogs(catalogs []Catalog, pre string, ja strings.Builder) []Catalog {
+func addJaCatalogs(catalogs []Catalog, pre string, ja strings.Builder, post string) []Catalog {
 	if ja.Len() == 0 {
 		return catalogs
 	}
-
 	catalog := Catalog{
-		pre: pre,
-		ja:  strings.TrimSuffix(ja.String(), "\n"),
+		pre:  pre,
+		ja:   strings.TrimSuffix(ja.String(), "\n"),
+		post: post,
 	}
 	catalogs = append(catalogs, catalog)
 	return catalogs

--- a/jpugdoc/replace.go
+++ b/jpugdoc/replace.go
@@ -156,12 +156,16 @@ func (rep *Rep) replaceTitle(src []byte) []byte {
 		nja := ""
 		if strings.Contains(ent, "Release ") {
 			v := RELEASENUM.Find(en)
-			nja = "<title>リリース" + string(v) + "</title>"
+			if v != nil {
+				nja = "<title>リリース" + string(v) + "</title>"
+			}
 		}
 
 		if strings.Contains(ent, "Migration to Version") {
 			v := RELEASENUM.Find(en)
-			nja = "<title>バージョン" + string(v) + "への移行</title>"
+			if v != nil {
+				nja = "<title>バージョン" + string(v) + "への移行</title>"
+			}
 		}
 
 		if j, ok := rep.titles[ent]; ok {
@@ -283,6 +287,9 @@ func foundReplace(src []byte, catalog Catalog) int {
 		if j == -1 {
 			// before conversion.
 			return p + i
+		}
+		if strings.Contains(catalog.ja, "split-") {
+			break
 		}
 		// Already converted.
 		p = p + i + j + len(catalog.pre) + 1


### PR DESCRIPTION
Prevented the same split-line from being added.
The title "Release Notes" is now processed correctly.

Prevented the same split-row from being added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added multilingual support for "Release Notes" titles, now including Japanese.
- **Enhancements**
	- Improved title replacement logic to better handle specific string conditions and enhance processing efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->