### PR TITLE
Add word check

### DIFF
--- a/jpugdoc/check.go
+++ b/jpugdoc/check.go
@@ -227,7 +227,7 @@ func translationCheck(fileName string, src []byte, cf CheckFlag) {
 	ignoreList := loadIgnore(fileName)
 
 	if len(results) > 0 {
-		fmt.Println(gchalk.Green(fileName))
+		fmt.Println(gchalk.WithBgYellow().Black(fileName))
 		for _, r := range results {
 			if ignoreList[strings.TrimRight(r.en, "\n")] {
 				continue

--- a/jpugdoc/word.go
+++ b/jpugdoc/word.go
@@ -25,9 +25,11 @@ func CheckWord(en string, ja string, vTag string, fileNames []string) error {
 		}
 		pairs := Extraction(src)
 		for _, pair := range pairs {
-			if strings.Contains(pair.en, en) {
-				if !strings.Contains(pair.ja, ja) {
-					fmt.Fprintf(w, "%s not include word)\n", fileName)
+			s := strings.ReplaceAll(pair.en, "\n", " ")
+			s = strings.Join(strings.Fields(s), " ")
+			if en == "" || strings.Contains(s, en) {
+				if ja == "" || (!strings.Contains(pair.ja, ja) && !strings.Contains(pair.ja, en)) {
+					fmt.Println(gchalk.WithBgYellow().Black(fileName))
 					fmt.Fprintln(w, gchalk.Green(pair.en))
 					fmt.Fprintln(w, pair.ja)
 				}


### PR DESCRIPTION
word check outputs sentences that do not include Japanese translations in the specified English.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced word matching and comparison logic in the translation check tool.
	- Improved handling of newline characters in translation texts.
- **Style**
	- Updated output styling for better readability in the translation check tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->