### PR TITLE
不一致文の範囲指定をブロックで探すように変更

### DIFF
--- a/jpugdoc/regexp.go
+++ b/jpugdoc/regexp.go
@@ -7,6 +7,9 @@ import (
 // <para> </para> に一致させる
 var REPARA = regexp.MustCompile(`(?s)(<para>\n*)(.*?)(\s*</para>)`)
 
+// <para>の単独タグ(\s+<programlisting>\nなど)に一致させる
+var REPARABLOCK = regexp.MustCompile(`^\s*<([^>]+)>\n`)
+
 // <para> <screen>|<programlisting> に一致させる
 var REPARASCREEN = regexp.MustCompile(`(?s)(<para>\n*)(.*?)(\s*(</para>|<screen>|<programlisting>))`)
 
@@ -74,6 +77,7 @@ func StripEntry(src []byte) []byte {
 var RECOMMENT = regexp.MustCompile(`(?s)<!--(.*?)-->`)
 
 var COMMENTSTART = regexp.MustCompile(`<!--`)
+var COMMENTEND = regexp.MustCompile(`-->`)
 
 // コメントが含まれていれば true
 func containComment(src []byte) bool {

--- a/jpugdoc/replace_test.go
+++ b/jpugdoc/replace_test.go
@@ -83,7 +83,6 @@ func TestRep_findSimilar(t *testing.T) {
 		prompt   bool
 	}
 	type args struct {
-		src   []byte
 		enStr string
 	}
 	tests := []struct {
@@ -105,7 +104,6 @@ func TestRep_findSimilar(t *testing.T) {
 				similar: 50,
 			},
 			args: args{
-				src:   []byte("This is a test1.\n"),
 				enStr: "This is a test1.",
 			},
 			want:  "これはテストです。",
@@ -123,7 +121,6 @@ func TestRep_findSimilar(t *testing.T) {
 				similar: 50,
 			},
 			args: args{
-				src:   []byte("This is a test.\n"),
 				enStr: "This is a test.",
 			},
 			want:  "これはテストです。",
@@ -140,7 +137,7 @@ func TestRep_findSimilar(t *testing.T) {
 				mt:       tt.fields.mt,
 				prompt:   tt.fields.prompt,
 			}
-			got, got1 := rep.findSimilar(tt.args.src, tt.args.enStr)
+			got, got1 := rep.findSimilar(tt.args.enStr)
 			if got != tt.want {
 				t.Errorf("Rep.findSimilar() got = %v, want %v", got, tt.want)
 			}


### PR DESCRIPTION
para内をさらに探す方法からタグ単独の行をブロックとして探すように変更した。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced enhanced handling for `<para>` tags with specific attributes in documentation processing.
- **Bug Fixes**
	- Improved comment ending detection within code documentation.
- **Refactor**
	- Optimized text replacement logic for better handling of documentation blocks and empty lines.
	- Enhanced similarity detection in text for more accurate processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->