### PR TITLE
Add sprit option to list command

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -13,7 +13,7 @@ var listCmd = &cobra.Command{
 	Short: "辞書から英語と日本語訳のリストを出力する",
 	Long:  `抽出した辞書の英語と日本語訳のリストを出力する`,
 	Run: func(cmd *cobra.Command, args []string) {
-		var filename, pre, enOnly, jaOnly, tsv bool
+		var filename, pre, enOnly, jaOnly, tsv, strip bool
 		var err error
 		if filename, err = cmd.PersistentFlags().GetBool("filename"); err != nil {
 			log.Println(err)
@@ -35,13 +35,17 @@ var listCmd = &cobra.Command{
 			log.Println(err)
 			return
 		}
+		if strip, err = cmd.PersistentFlags().GetBool("strip"); err != nil {
+			log.Println(err)
+			return
+		}
 
 		fileNames := expandFileNames(args)
 		if tsv {
-			jpugdoc.TSVList(fileNames)
+			jpugdoc.TSVList(strip, fileNames)
 			return
 		}
-		jpugdoc.List(filename, pre, enOnly, jaOnly, fileNames)
+		jpugdoc.List(filename, pre, enOnly, jaOnly, strip, fileNames)
 	},
 }
 
@@ -52,4 +56,5 @@ func init() {
 	listCmd.PersistentFlags().BoolP("en", "e", false, "English")
 	listCmd.PersistentFlags().BoolP("ja", "j", false, "Japanese")
 	listCmd.PersistentFlags().BoolP("tsv", "t", false, "tsv")
+	listCmd.PersistentFlags().BoolP("strip", "s", false, "strip")
 }

--- a/jpugdoc/list.go
+++ b/jpugdoc/list.go
@@ -16,12 +16,12 @@ import (
 // enOnly: 英文のみ表示する
 // jaOnly: 日本語のみ表示する
 // fileNames: ファイル名のリスト
-func List(wf bool, pre bool, enOnly bool, jaOnly bool, fileNames []string) {
+func List(wf bool, pre bool, enOnly bool, jaOnly bool, strip bool, fileNames []string) {
 	w := io.Writer(os.Stdout)
-	list(w, wf, pre, enOnly, jaOnly, fileNames)
+	list(w, wf, pre, enOnly, jaOnly, strip, fileNames)
 }
 
-func list(w io.Writer, wf bool, pre bool, enOnly bool, jaOnly bool, fileNames []string) {
+func list(w io.Writer, wf bool, pre bool, enOnly bool, jaOnly bool, strip bool, fileNames []string) {
 	for _, fileName := range fileNames {
 		if wf {
 			fmt.Fprintln(w, gchalk.Red(fileName))
@@ -30,13 +30,18 @@ func list(w io.Writer, wf bool, pre bool, enOnly bool, jaOnly bool, fileNames []
 		if err != nil {
 			log.Println(err)
 		}
-		writeCatalog(w, catalogs, pre, enOnly, jaOnly)
+		writeCatalog(w, catalogs, pre, enOnly, jaOnly, strip)
 	}
 }
 
-func writeCatalog(w io.Writer, catalogs []Catalog, suffix bool, enOnly bool, jaOnly bool) {
+func writeCatalog(w io.Writer, catalogs []Catalog, suffix bool, enOnly bool, jaOnly bool, strip bool) {
 	for _, catalog := range catalogs {
-		en := strings.Trim(catalog.en, "\n")
+		en := catalog.en
+		if strip {
+			en = stripNL(en)
+			en = strings.Join(strings.Fields(en), " ")
+		}
+		en = strings.Trim(en, "\n")
 		if !suffix && en == "" {
 			continue
 		}
@@ -47,8 +52,13 @@ func writeCatalog(w io.Writer, catalogs []Catalog, suffix bool, enOnly bool, jaO
 		if !jaOnly {
 			fmt.Fprintln(w, gchalk.Green(en))
 		}
+		ja := catalog.ja
+		if strip {
+			ja = stripNL(ja)
+			ja = strings.Join(strings.Fields(ja), " ")
+		}
 		if !enOnly {
-			fmt.Fprintln(w, strings.Trim(catalog.ja, "\n"))
+			fmt.Fprintln(w, strings.Trim(ja, "\n"))
 		}
 		if suffix {
 			fmt.Fprintln(w, gchalk.Blue(strings.Trim(catalog.post, "\n")))
@@ -58,23 +68,37 @@ func writeCatalog(w io.Writer, catalogs []Catalog, suffix bool, enOnly bool, jaO
 }
 
 // 英日辞書の内容をTSV形式で表示する
-func TSVList(fileNames []string) {
+func TSVList(strip bool, fileNames []string) {
 	w := io.Writer(os.Stdout)
-	tsvList(w, fileNames)
+	tsvList(w, strip, fileNames)
 }
 
-func tsvList(w io.Writer, fileNames []string) {
+func tsvList(w io.Writer, strip bool, fileNames []string) {
 	for _, fileName := range fileNames {
 		catalogs, err := loadCatalog(fileName)
 		if err != nil {
 			log.Println(err)
 		}
-		writeTSV(w, catalogs)
+		writeTSV(w, strip, catalogs)
 	}
 }
 
-func writeTSV(w io.Writer, catalogs []Catalog) {
+func writeTSV(w io.Writer, strip bool, catalogs []Catalog) {
 	for _, catalog := range catalogs {
-		fmt.Fprintf(w, "%s\t%s\n", strings.ReplaceAll(catalog.en, "\n", " "), strings.ReplaceAll(catalog.ja, "\n", " "))
+		en := catalog.en
+		if strip {
+			en = stripNL(en)
+			en = strings.Join(strings.Fields(en), " ")
+		} else {
+			en = strings.ReplaceAll(en, "\n", " ")
+		}
+		ja := catalog.ja
+		if strip {
+			ja = stripNL(ja)
+			ja = strings.Join(strings.Fields(ja), " ")
+		} else {
+			ja = strings.ReplaceAll(ja, "\n", " ")
+		}
+		fmt.Fprintf(w, "%s\t%s\n", en, ja)
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a `strip` option to the list command, allowing users to strip newlines and join fields in the output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->